### PR TITLE
Fix unmount behaviour

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,9 @@ const useCountDown = (timeToCount = 60 * 1000, interval = 1000) => {
     [],
   );
 
-  React.useEffect(() => reset, []);
+  React.useEffect(() => {
+    return () => window.cancelAnimationFrame(timer.current.requestId);
+  }, []);
 
   return [timeLeft, actions];
 }


### PR DESCRIPTION
This PR fixes the unmount behavior, that by calling `reset` was performing a state update, and thus triggering the famous react warning:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

Only `window.cancelAnimationFrame` should be called on unmount.